### PR TITLE
Add blink interval distribution feature

### DIFF
--- a/pyear/blink_events/event_features/__init__.py
+++ b/pyear/blink_events/event_features/__init__.py
@@ -3,10 +3,12 @@ from .aggregate import aggregate_blink_event_features
 from .blink_count import blink_count_epoch
 from .blink_rate import blink_rate_epoch
 from .inter_blink_interval import compute_ibi_features
+from .blink_interval_distribution import blink_interval_distribution
 
 __all__ = [
     "aggregate_blink_event_features",
     "blink_count_epoch",
     "blink_rate_epoch",
     "compute_ibi_features",
+    "blink_interval_distribution",
 ]

--- a/pyear/blink_events/event_features/blink_interval_distribution.py
+++ b/pyear/blink_events/event_features/blink_interval_distribution.py
@@ -1,0 +1,58 @@
+"""Histogram of inter-blink intervals for an entire session."""
+from __future__ import annotations
+
+from typing import Iterable, Dict, Sequence
+
+import logging
+import numpy as np
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def blink_interval_distribution(
+    blinks: Iterable[Dict[str, int]],
+    sfreq: float,
+    bins: int | Sequence[float] = 10,
+) -> pd.DataFrame:
+    """Return a histogram of inter-blink intervals.
+
+    Parameters
+    ----------
+    blinks : iterable of dict
+        Blink annotations with ``refined_start_frame`` and
+        ``refined_end_frame`` fields as integers and an ``epoch_index``
+        identifying the epoch.
+    sfreq : float
+        Sampling frequency of the recording in Hertz.
+    bins : int | sequence of float, optional
+        Number of histogram bins or the explicit bin edges. Defaults to ``10``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with columns ``bin_start``, ``bin_end`` and ``count``.
+    """
+    logger.info("Computing blink interval distribution with %s bins", bins)
+
+    starts = []
+    ends = []
+    for b in blinks:
+        epoch_offset = b.get("epoch_index", 0) * sfreq
+        starts.append(epoch_offset + b["refined_start_frame"])
+        ends.append(epoch_offset + b["refined_end_frame"])
+    if len(starts) < 2:
+        return pd.DataFrame({"bin_start": [], "bin_end": [], "count": []})
+    order = np.argsort(starts)
+    starts = np.asarray(starts)[order]
+    ends = np.asarray(ends)[order]
+    ibis = (starts[1:] - ends[:-1]) / sfreq
+
+    counts, edges = np.histogram(ibis, bins=bins)
+    df = pd.DataFrame({
+        "bin_start": edges[:-1],
+        "bin_end": edges[1:],
+        "count": counts,
+    })
+    logger.debug("IBI histogram:\n%s", df)
+    return df

--- a/unitest/test_blink_interval_distribution.py
+++ b/unitest/test_blink_interval_distribution.py
@@ -1,0 +1,38 @@
+"""Unit tests for blink interval distribution calculation."""
+
+import unittest
+import logging
+
+from pyear.blink_events.event_features.blink_interval_distribution import (
+    blink_interval_distribution,
+)
+from unitest.fixtures.mock_ear_generation import _generate_refined_ear
+
+logger = logging.getLogger(__name__)
+
+
+class TestBlinkIntervalDistribution(unittest.TestCase):
+    """Tests for ``blink_interval_distribution`` utility."""
+
+    def setUp(self) -> None:
+        logger.info("Preparing synthetic blink data for distribution tests...")
+        blinks, sfreq, epoch_len, n_epochs = _generate_refined_ear()
+        self.sfreq = sfreq
+        self.blinks = blinks
+        self.n_intervals = len(blinks) - 1
+
+    def test_histogram_counts(self) -> None:
+        """Histogram counts should sum to the number of intervals."""
+        df = blink_interval_distribution(self.blinks, self.sfreq, bins=4)
+        total = int(df["count"].sum())
+        logger.debug(
+            "Histogram counts: %s (total %s)",
+            df["count"].tolist(),
+            total,
+        )
+        self.assertEqual(total, self.n_intervals)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `blink_interval_distribution` to compute histogram of inter-blink intervals
- expose the function in `blink_events.event_features`
- test blink interval distribution behaviour

## Testing
- `flake8 unitest/test_blink_interval_distribution.py pyear/blink_events/event_features/blink_interval_distribution.py`
- `PYTHONPATH=. python unitest/run_all_test.py`

------
https://chatgpt.com/codex/tasks/task_e_685ead32c7f083259c6e90053320dd21