### PR TITLE
Add frequency-domain features and helper utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Power spectral and rhythm descriptors:
 ```bash
 git clone [https://github.com/your-username/pyear.git](https://github.com/balandongiv/pyear.git)
 cd pyear
-pip install -r requirements.txt
+pip install -e .
 ```
 
 ---
@@ -137,6 +137,8 @@ See [docs/FEATURES.md](docs/FEATURES.md) for detailed descriptions and formulas 
 * Frequency bands
 * Complexity measures
 * State modeling strategies
+
+Additional examples can be found in [docs/tutorial.ipynb](docs/tutorial.ipynb).
 
 ---
 

--- a/docs/tutorial.ipynb
+++ b/docs/tutorial.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f83622c1",
+   "metadata": {},
+   "source": [
+    "# pyear Tutorial\n",
+    "This notebook demonstrates feature extraction including frequency-domain metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6b660b4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyear.pipeline import extract_features\n",
+    "from pyear.utils.epoch_aggregator import slice_raw_to_epochs\n",
+    "from unitest.fixtures.mock_ear_generation import _generate_signal_with_blinks\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "signal, annotations = _generate_signal_with_blinks(100.0, 30.0, 1)\n",
+    "blinks = slice_raw_to_epochs(signal, annotations, 100.0, 30.0)\n",
+    "features = extract_features(blinks, 100.0, 30.0, 1, features=[\"frequency\"])\n",
+    "print(features.head())\n",
+    "plt.plot(signal)\n",
+    "plt.title(\"Synthetic eyelid trace\")\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyear/frequency_domain/__init__.py
+++ b/pyear/frequency_domain/__init__.py
@@ -1,0 +1,4 @@
+"""Frequency-domain feature module."""
+from .aggregate import aggregate_frequency_domain_features
+
+__all__ = ["aggregate_frequency_domain_features"]

--- a/pyear/frequency_domain/aggregate.py
+++ b/pyear/frequency_domain/aggregate.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any, List
+import logging
+import pandas as pd
+import numpy as np
+
+from .frequency_features import compute_frequency_domain_features
+
+logger = logging.getLogger(__name__)
+
+
+def aggregate_frequency_domain_features(
+    blinks: Iterable[Dict[str, Any]],
+    sfreq: float,
+    n_epochs: int,
+) -> pd.DataFrame:
+    """Aggregate spectral and wavelet metrics across epochs.
+
+    Parameters
+    ----------
+    blinks : Iterable[dict]
+        Blink annotations containing ``epoch_index`` and ``epoch_signal``.
+    sfreq : float
+        Sampling frequency in Hertz.
+    n_epochs : int
+        Number of epochs to aggregate.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame indexed by epoch with frequency-domain features.
+    """
+    logger.info("Aggregating frequency-domain features over %d epochs", n_epochs)
+
+    per_epoch_signals: List[np.ndarray | None] = [None for _ in range(n_epochs)]
+    for blink in blinks:
+        idx = blink["epoch_index"]
+        if 0 <= idx < n_epochs and per_epoch_signals[idx] is None:
+            per_epoch_signals[idx] = np.asarray(blink["epoch_signal"], dtype=float)
+
+    records = []
+    for idx in range(n_epochs):
+        signal = per_epoch_signals[idx]
+        record = {"epoch": idx}
+        if signal is not None:
+            feats = compute_frequency_domain_features(signal, sfreq)
+            record.update(feats)
+        else:
+            record.update(
+                {
+                    "peak_frequency": float("nan"),
+                    "peak_power": float("nan"),
+                    "band_power_ratio": float("nan"),
+                    "one_over_f_slope": float("nan"),
+                    "wavelet_energy_d1": float("nan"),
+                    "wavelet_energy_d2": float("nan"),
+                    "wavelet_energy_d3": float("nan"),
+                    "wavelet_energy_d4": float("nan"),
+                }
+            )
+        records.append(record)
+
+    df = pd.DataFrame.from_records(records).set_index("epoch")
+    logger.debug("Aggregated frequency-domain DataFrame shape: %s", df.shape)
+    return df

--- a/pyear/frequency_domain/frequency_features.py
+++ b/pyear/frequency_domain/frequency_features.py
@@ -1,0 +1,74 @@
+"""Power spectral and wavelet energy features."""
+from __future__ import annotations
+
+from typing import Dict
+import logging
+
+import numpy as np
+from scipy.signal import welch
+import pywt
+
+logger = logging.getLogger(__name__)
+
+
+def compute_frequency_domain_features(epoch_signal: np.ndarray, sfreq: float) -> Dict[str, float]:
+    """Compute spectral peak and wavelet energy metrics for an epoch.
+
+    Parameters
+    ----------
+    epoch_signal : numpy.ndarray
+        Eyelid aperture samples for one epoch.
+    sfreq : float
+        Sampling frequency in Hertz.
+
+    Returns
+    -------
+    dict
+        Dictionary containing power spectral and wavelet energy features.
+    """
+    if epoch_signal.size == 0:
+        return {
+            "peak_frequency": float("nan"),
+            "peak_power": float("nan"),
+            "band_power_ratio": float("nan"),
+            "one_over_f_slope": float("nan"),
+            "wavelet_energy_d1": float("nan"),
+            "wavelet_energy_d2": float("nan"),
+            "wavelet_energy_d3": float("nan"),
+            "wavelet_energy_d4": float("nan"),
+        }
+
+    freqs, psd = welch(epoch_signal, fs=sfreq, nperseg=min(256, epoch_signal.size))
+    peak_idx = int(np.argmax(psd))
+    peak_freq = float(freqs[peak_idx])
+    peak_power = float(psd[peak_idx])
+
+    low_mask = (freqs >= 0.5) & (freqs <= 2.0)
+    high_mask = (freqs > 2.0) & (freqs <= 10.0)
+    low_power = float(np.trapz(psd[low_mask], freqs[low_mask]))
+    high_power = float(np.trapz(psd[high_mask], freqs[high_mask]))
+    band_ratio = low_power / high_power if high_power != 0 else float("nan")
+
+    if np.all(psd[1:] > 0):
+        log_freqs = np.log10(freqs[1:])
+        log_psd = np.log10(psd[1:])
+        slope, _ = np.polyfit(log_freqs, log_psd, 1)
+        one_over_f_slope = float(-slope)
+    else:
+        one_over_f_slope = float("nan")
+
+    coeffs = pywt.wavedec(epoch_signal, "db4", level=4)
+    energies = {
+        f"wavelet_energy_d{idx}": float(np.sum(detail ** 2))
+        for idx, detail in enumerate(coeffs[1:], start=1)
+    }
+
+    features = {
+        "peak_frequency": peak_freq,
+        "peak_power": peak_power,
+        "band_power_ratio": band_ratio,
+        "one_over_f_slope": one_over_f_slope,
+    }
+    features.update(energies)
+    logger.debug("Frequency features: %s", features)
+    return features

--- a/pyear/pipeline.py
+++ b/pyear/pipeline.py
@@ -15,6 +15,7 @@ from .open_eye import aggregate_open_eye_features
 from .ear_metrics import aggregate_ear_features
 from .waveform_features import aggregate_waveform_features
 from .blink_events.classification import aggregate_classification_features
+from .frequency_domain import aggregate_frequency_domain_features
 
 # Configure root logger
 logging.basicConfig(level=logging.INFO)
@@ -79,6 +80,10 @@ def extract_features(
     if features is None or "open_eye" in features:
         df_open = aggregate_open_eye_features(blinks, sfreq, n_epochs)
         df_events = pd.concat([df_events, df_open], axis=1)
+
+    if features is None or "frequency" in features:
+        df_freq = aggregate_frequency_domain_features(blinks, sfreq, n_epochs)
+        df_events = pd.concat([df_events, df_freq], axis=1)
 
     if features is None or "waveform" in features:
         df_wave = aggregate_waveform_features(blinks, sfreq, n_epochs)

--- a/pyear/utils/epoch_aggregator.py
+++ b/pyear/utils/epoch_aggregator.py
@@ -1,1 +1,62 @@
-"""Utilities to aggregate blink features per epoch."""
+"""Utilities for epoch handling and annotation."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Dict, Any
+import logging
+import numpy as np
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+def slice_raw_to_epochs(
+    signal: np.ndarray,
+    annotations: Iterable[Dict[str, int]],
+    sfreq: float,
+    epoch_len: float = 30.0,
+) -> List[Dict[str, Any]]:
+    """Slice a continuous recording into annotated epochs.
+
+    Parameters
+    ----------
+    signal : numpy.ndarray
+        Full eyelid aperture recording.
+    annotations : Iterable[dict]
+        Blink annotations with ``start``, ``trough`` and ``end`` indices.
+    sfreq : float
+        Sampling frequency in Hertz.
+    epoch_len : float, optional
+        Length of each epoch in seconds, by default ``30.0``.
+
+    Returns
+    -------
+    list of dict
+        Blink annotations including ``epoch_index`` and ``epoch_signal``.
+    """
+
+    samples_per_epoch = int(epoch_len * sfreq)
+    n_epochs = int(np.ceil(len(signal) / samples_per_epoch))
+    results: List[Dict[str, Any]] = []
+
+    for epoch_idx in tqdm(range(n_epochs), desc="Slicing epochs"):
+        start = epoch_idx * samples_per_epoch
+        end = min(len(signal), start + samples_per_epoch)
+        epoch_signal = signal[start:end]
+        epoch_annotations = [
+            ann for ann in annotations if start <= ann["trough"] < end
+        ]
+        for ann in epoch_annotations:
+            entry = ann.copy()
+            entry["epoch_index"] = epoch_idx
+            entry["epoch_signal"] = epoch_signal
+            entry["refined_start_frame"] = ann["start"] - start
+            entry["refined_peak_frame"] = ann["trough"] - start
+            entry["refined_end_frame"] = ann["end"] - start
+            results.append(entry)
+
+    logger.info("Sliced raw signal into %d epochs", n_epochs)
+    return results
+
+
+__all__ = ["slice_raw_to_epochs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyear"
+version = "0.1.0"
+description = "Blink and eyelid aperture feature extraction toolkit"
+authors = [{name = "pyear contributors"}]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "numpy",
+    "pandas",
+    "mne",
+    "tqdm",
+    "PyWavelets",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 tqdm
 pandas
 mne
+numpy
+PyWavelets
 

--- a/unitest/test_frequency_domain_features.py
+++ b/unitest/test_frequency_domain_features.py
@@ -1,0 +1,38 @@
+"""Unit tests for frequency-domain feature extraction."""
+import unittest
+import logging
+
+from pyear.frequency_domain.frequency_features import compute_frequency_domain_features
+from pyear.frequency_domain import aggregate_frequency_domain_features
+from unitest.fixtures.mock_ear_generation import _generate_refined_ear
+
+logger = logging.getLogger(__name__)
+
+
+class TestFrequencyDomainFeatures(unittest.TestCase):
+    """Verify frequency-domain metrics."""
+
+    def setUp(self) -> None:
+        blinks, sfreq, epoch_len, n_epochs = _generate_refined_ear()
+        self.sfreq = sfreq
+        self.n_epochs = n_epochs
+        self.blinks = blinks
+        self.signal0 = blinks[0]["epoch_signal"]
+
+    def test_single_epoch(self) -> None:
+        """Check computation on one epoch."""
+        feats = compute_frequency_domain_features(self.signal0, self.sfreq)
+        logger.debug("Frequency features: %s", feats)
+        self.assertIn("peak_frequency", feats)
+        self.assertFalse(feats["peak_power"] is None)
+
+    def test_aggregate_shape(self) -> None:
+        """Aggregated DataFrame should contain expected columns."""
+        df = aggregate_frequency_domain_features(self.blinks, self.sfreq, self.n_epochs)
+        self.assertIn("wavelet_energy_d1", df.columns)
+        self.assertEqual(len(df), self.n_epochs)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/unitest/test_slice_helper.py
+++ b/unitest/test_slice_helper.py
@@ -1,0 +1,28 @@
+"""Tests for the slice_raw_to_epochs helper."""
+import unittest
+import logging
+
+import numpy as np
+
+from pyear.utils.epoch_aggregator import slice_raw_to_epochs
+from unitest.fixtures.mock_ear_generation import _generate_signal_with_blinks
+
+logger = logging.getLogger(__name__)
+
+
+class TestSliceHelper(unittest.TestCase):
+    """Ensure raw slicing works correctly."""
+
+    def setUp(self) -> None:
+        self.signal, self.annotations = _generate_signal_with_blinks(100.0, 30.0, 2)
+
+    def test_output_structure(self) -> None:
+        """Returned annotations include epoch info."""
+        sliced = slice_raw_to_epochs(self.signal, self.annotations, 100.0, 30.0)
+        self.assertTrue(all("epoch_index" in b for b in sliced))
+        self.assertTrue(all("epoch_signal" in b for b in sliced))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement power spectrum and wavelet energy metrics
- add helper for slicing continuous data into epochs
- integrate frequency features in pipeline
- provide packaging via `pyproject.toml`
- include tutorial notebook with examples
- add tests for new functionality

## Testing
- `pip install -r requirements.txt`
- `python -m unittest discover -v unitest`

------
https://chatgpt.com/codex/tasks/task_e_685eada8199c8325a36abc1a0e8e1fb5