### PR TITLE
Fix deprecation warnings in blink feature calculations

### DIFF
--- a/pyear/energy_complexity/per_blink.py
+++ b/pyear/energy_complexity/per_blink.py
@@ -37,7 +37,7 @@ def compute_blink_energy_complexity(blink: Dict[str, Any], sfreq: float) -> Dict
     segment = signal[start : end + 1]
     dt = 1.0 / sfreq
 
-    energy = float(np.trapz(segment ** 2, dx=dt))
+    energy = float(np.trapezoid(segment ** 2, dx=dt))
 
     if segment.size > 2:
         tkeo = segment[1:-1] ** 2 - segment[:-2] * segment[2:]
@@ -48,7 +48,7 @@ def compute_blink_energy_complexity(blink: Dict[str, Any], sfreq: float) -> Dict
     line_length = float(np.sum(np.abs(np.diff(segment))))
 
     velocity = np.gradient(segment, dt)
-    vel_integral = float(np.trapz(np.abs(velocity), dx=dt))
+    vel_integral = float(np.trapezoid(np.abs(velocity), dx=dt))
 
     logger.debug(
         "Blink energy: energy=%s, teager=%s, line_length=%s, vel_int=%s",

--- a/pyear/morphology/per_blink.py
+++ b/pyear/morphology/per_blink.py
@@ -53,7 +53,7 @@ def compute_single_blink_features(blink: Dict[str, Any], sfreq: float) -> Dict[s
     idx_up = next((i for i, v in enumerate(up_seg) if v <= thresh50), len(up_seg) - 1)
     fwhm = (idx_up + peak - start - idx_down) / sfreq
 
-    area = float(np.trapz(baseline - segment, dx=1 / sfreq))
+    area = float(np.trapezoid(baseline - segment, dx=1 / sfreq))
     cumulative = np.cumsum(baseline - segment) / sfreq
     half_area = cumulative[-1] / 2
     idx_half = next((i for i, v in enumerate(cumulative) if v >= half_area), len(cumulative) - 1)


### PR DESCRIPTION
## Summary
- switch from `np.trapz` to `np.trapezoid` to avoid numpy 2.0 deprecation warnings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f53474594832596f44c1f954d3c44