### PR TITLE
Implement spectral features and raw slicing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Power spectral and rhythm descriptors:
 ```bash
 git clone [https://github.com/your-username/pyear.git](https://github.com/balandongiv/pyear.git)
 cd pyear
-pip install -r requirements.txt
+pip install .
 ```
 
 ---
@@ -136,9 +136,12 @@ features.head()
 ```
 
 The ``blinks`` list can be built with the provided segmentation helpers
-(see ``unitest/fixtures/mock_ear_generation.py``).  When requesting the
+(see ``unitest/fixtures/mock_ear_generation.py``).  When working with a
+continuous ``mne.Raw`` recording, the new
+``pyear.utils.slice_raw_to_segments`` helper slices the raw file into
+30‑second annotated segments with a progress bar.  When requesting the
 ``blink_interval_dist`` feature, supply ``raw_segments`` as a list of
-the original per-epoch signals.
+the original per‑epoch signals.
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,0 +1,14 @@
+# Blink Feature Overview
+
+This document summarizes the available blink metrics in `pyear`.
+
+## Frequency-Domain Features
+
+* **blink_rate_peak_freq** – dominant blink rhythm between 0.1‑0.5 Hz.
+* **blink_rate_peak_power** – spectral power at that peak frequency.
+* **broadband_power_0_5_2** – total power of the eyelid signal between 0.5‑2 Hz.
+* **broadband_com_0_5_2** – center of mass of the 0.5‑2 Hz band.
+* **high_freq_entropy_2_13** – spectral entropy in the 2‑13 Hz band.
+* **one_over_f_slope** – slope of the 1/f fit from 0.5‑13 Hz.
+* **band_power_ratio** – (0.5‑2 Hz) / (2‑13 Hz) power ratio.
+* **wavelet_energy_d1..d4** – energies of detail levels from a four‑level DWT.

--- a/pyear/frequency_domain/__init__.py
+++ b/pyear/frequency_domain/__init__.py
@@ -1,0 +1,4 @@
+"""Frequency-domain feature extraction package."""
+from .aggregate import aggregate_frequency_domain_features
+
+__all__ = ["aggregate_frequency_domain_features"]

--- a/pyear/frequency_domain/aggregate.py
+++ b/pyear/frequency_domain/aggregate.py
@@ -1,0 +1,72 @@
+"""Aggregate frequency-domain features across epochs."""
+from __future__ import annotations
+
+from typing import Iterable, Dict, Any, List
+import logging
+import pandas as pd
+import numpy as np
+
+from .features import compute_frequency_domain_features
+
+logger = logging.getLogger(__name__)
+
+
+def aggregate_frequency_domain_features(
+    blinks: Iterable[Dict[str, Any]],
+    sfreq: float,
+    n_epochs: int,
+) -> pd.DataFrame:
+    """Aggregate frequency-domain metrics for multiple epochs.
+
+    Parameters
+    ----------
+    blinks : Iterable[dict]
+        Blink annotations with ``epoch_index`` and ``epoch_signal``.
+    sfreq : float
+        Sampling frequency in Hertz.
+    n_epochs : int
+        Number of epochs to aggregate.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame indexed by epoch with frequency-domain features.
+    """
+    logger.info("Aggregating frequency-domain features over %d epochs", n_epochs)
+    per_epoch_signal: List[np.ndarray | None] = [None for _ in range(n_epochs)]
+    per_epoch_blinks: List[List[Dict[str, Any]]] = [list() for _ in range(n_epochs)]
+
+    for blink in blinks:
+        idx = blink["epoch_index"]
+        if 0 <= idx < n_epochs:
+            per_epoch_blinks[idx].append(blink)
+            if per_epoch_signal[idx] is None:
+                per_epoch_signal[idx] = np.asarray(blink["epoch_signal"], dtype=float)
+
+    records = []
+    for idx in range(n_epochs):
+        signal = per_epoch_signal[idx]
+        blinks_epoch = per_epoch_blinks[idx]
+        if signal is None:
+            feats = {
+                "blink_rate_peak_freq": float("nan"),
+                "blink_rate_peak_power": float("nan"),
+                "broadband_power_0_5_2": float("nan"),
+                "broadband_com_0_5_2": float("nan"),
+                "high_freq_entropy_2_13": float("nan"),
+                "one_over_f_slope": float("nan"),
+                "band_power_ratio": float("nan"),
+                "wavelet_energy_d1": float("nan"),
+                "wavelet_energy_d2": float("nan"),
+                "wavelet_energy_d3": float("nan"),
+                "wavelet_energy_d4": float("nan"),
+            }
+        else:
+            feats = compute_frequency_domain_features(blinks_epoch, signal, sfreq)
+        record = {"epoch": idx}
+        record.update(feats)
+        records.append(record)
+
+    df = pd.DataFrame.from_records(records).set_index("epoch")
+    logger.debug("Aggregated frequency-domain DataFrame shape: %s", df.shape)
+    return df

--- a/pyear/frequency_domain/features.py
+++ b/pyear/frequency_domain/features.py
@@ -1,0 +1,121 @@
+"""Frequency-domain feature calculations."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import logging
+
+import numpy as np
+import pywt
+
+logger = logging.getLogger(__name__)
+
+
+def compute_frequency_domain_features(
+    blinks: List[Dict[str, Any]],
+    epoch_signal: np.ndarray,
+    sfreq: float,
+) -> Dict[str, float]:
+    """Compute spectral and wavelet metrics for one epoch.
+
+    Parameters
+    ----------
+    blinks : list of dict
+        Blink annotations belonging to the epoch.
+    epoch_signal : numpy.ndarray
+        Eyelid aperture samples for the epoch.
+    sfreq : float
+        Sampling frequency of the recording in Hertz.
+
+    Returns
+    -------
+    dict
+        Dictionary with frequency-domain features.
+    """
+    logger.info("Computing frequency-domain features for %d blinks", len(blinks))
+
+    n = len(epoch_signal)
+    if n == 0:
+        return {
+            "blink_rate_peak_freq": float("nan"),
+            "blink_rate_peak_power": float("nan"),
+            "broadband_power_0_5_2": float("nan"),
+            "broadband_com_0_5_2": float("nan"),
+            "high_freq_entropy_2_13": float("nan"),
+            "one_over_f_slope": float("nan"),
+            "band_power_ratio": float("nan"),
+            "wavelet_energy_d1": float("nan"),
+            "wavelet_energy_d2": float("nan"),
+            "wavelet_energy_d3": float("nan"),
+            "wavelet_energy_d4": float("nan"),
+        }
+
+    dt = 1.0 / sfreq
+    freqs = np.fft.rfftfreq(n, dt)
+    psd = np.abs(np.fft.rfft(epoch_signal)) ** 2 / n
+
+    def band_power(fmin: float, fmax: float) -> float:
+        mask = (freqs >= fmin) & (freqs <= fmax)
+        return float(np.sum(psd[mask]))
+
+    band_power_05_2 = band_power(0.5, 2.0)
+    mask_band = (freqs >= 0.5) & (freqs <= 2.0)
+    if np.any(mask_band) and np.sum(psd[mask_band]) > 0:
+        band_com = float(
+            np.sum(freqs[mask_band] * psd[mask_band]) / np.sum(psd[mask_band])
+        )
+    else:
+        band_com = float("nan")
+
+    mask_high = (freqs >= 2.0) & (freqs <= 13.0)
+    high_power = float(np.sum(psd[mask_high]))
+    if np.any(mask_high) and high_power > 0:
+        probs = psd[mask_high] / high_power
+        high_entropy = float(-np.sum(probs * np.log2(probs + 1e-12)))
+    else:
+        high_entropy = float("nan")
+
+    mask_all = (freqs >= 0.5) & (freqs <= 13.0)
+    if np.any(mask_all):
+        slope, _ = np.polyfit(np.log(freqs[mask_all]), np.log(psd[mask_all] + 1e-12), 1)
+        one_over_f = float(-slope)
+    else:
+        one_over_f = float("nan")
+
+    band_ratio = band_power_05_2 / high_power if high_power > 0 else float("nan")
+
+    coeffs = pywt.wavedec(epoch_signal, "db4", level=4)
+    energies = [float(np.sum(c ** 2)) for c in coeffs[1:5]]
+
+    indicator = np.zeros(n)
+    for blink in blinks:
+        idx = int(blink.get("refined_start_frame", 0))
+        if 0 <= idx < n:
+            indicator[idx] = 1.0
+    freqs_blink = np.fft.rfftfreq(n, dt)
+    blink_psd = np.abs(np.fft.rfft(indicator)) ** 2 / n
+    mask_blink = (freqs_blink >= 0.1) & (freqs_blink <= 0.5)
+    if np.any(mask_blink):
+        idx_max = np.argmax(blink_psd[mask_blink])
+        sub_freqs = freqs_blink[mask_blink]
+        sub_power = blink_psd[mask_blink]
+        blink_peak_freq = float(sub_freqs[idx_max])
+        blink_peak_power = float(sub_power[idx_max])
+    else:
+        blink_peak_freq = float("nan")
+        blink_peak_power = float("nan")
+
+    features = {
+        "blink_rate_peak_freq": blink_peak_freq,
+        "blink_rate_peak_power": blink_peak_power,
+        "broadband_power_0_5_2": band_power_05_2,
+        "broadband_com_0_5_2": band_com,
+        "high_freq_entropy_2_13": high_entropy,
+        "one_over_f_slope": one_over_f,
+        "band_power_ratio": band_ratio,
+        "wavelet_energy_d1": energies[0],
+        "wavelet_energy_d2": energies[1],
+        "wavelet_energy_d3": energies[2],
+        "wavelet_energy_d4": energies[3],
+    }
+    logger.debug("Frequency-domain features: %s", features)
+    return features

--- a/pyear/pipeline.py
+++ b/pyear/pipeline.py
@@ -18,6 +18,7 @@ from .energy_complexity import aggregate_energy_complexity_features
 from .open_eye import aggregate_open_eye_features
 from .ear_metrics import aggregate_ear_features
 from .waveform_features import aggregate_waveform_features
+from .frequency_domain import aggregate_frequency_domain_features
 from .blink_events.classification import aggregate_classification_features
 
 # Configure root logger
@@ -100,6 +101,10 @@ def extract_features(
     if features is None or "open_eye" in features:
         df_open = aggregate_open_eye_features(blinks, sfreq, n_epochs)
         df_events = pd.concat([df_events, df_open], axis=1)
+
+    if features is None or "frequency" in features:
+        df_freq = aggregate_frequency_domain_features(blinks, sfreq, n_epochs)
+        df_events = pd.concat([df_events, df_freq], axis=1)
 
     if features is None or "waveform" in features:
         df_wave = aggregate_waveform_features(blinks, sfreq, n_epochs)

--- a/pyear/utils/__init__.py
+++ b/pyear/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utility functions for pyear."""
+from .segments import slice_raw_to_segments
+
+__all__ = ["slice_raw_to_segments"]

--- a/pyear/utils/segments.py
+++ b/pyear/utils/segments.py
@@ -1,0 +1,36 @@
+"""Raw segmentation helpers."""
+from __future__ import annotations
+
+from typing import List
+import logging
+
+import mne
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+def slice_raw_to_segments(raw: mne.io.BaseRaw, epoch_len: float = 30.0) -> List[mne.io.BaseRaw]:
+    """Slice a continuous :class:`mne.io.BaseRaw` into fixed-length segments.
+
+    Parameters
+    ----------
+    raw : mne.io.BaseRaw
+        Continuous raw recording with blink annotations.
+    epoch_len : float, optional
+        Length of each segment in seconds, by default ``30.0``.
+
+    Returns
+    -------
+    list of mne.io.BaseRaw
+        List of cropped raw segments containing annotations.
+    """
+    n_segments = int(raw.times[-1] // epoch_len)
+    segments: List[mne.io.BaseRaw] = []
+    for i in tqdm(range(n_segments), desc="Segmenting", unit="segment"):
+        start = i * epoch_len
+        stop = start + epoch_len
+        seg = raw.copy().crop(tmin=start, tmax=stop, include_tmax=False)
+        segments.append(seg)
+    logger.info("Created %d segments", n_segments)
+    return segments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyear"
+version = "0.1.0"
+description = "Toolkit for blink-based fatigue analysis"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "pyear"}]
+dependencies = [
+    "mne",
+    "pandas",
+    "tqdm",
+    "PyWavelets",
+]
+
+[tool.setuptools]
+packages = ["pyear"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 tqdm
 pandas
 mne
+PyWavelets
 

--- a/tutorial/frequency_features.ipynb
+++ b/tutorial/frequency_features.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Frequency-Domain Blink Features\n",
+    "This example computes frequency features on a mock signal and plots the PSD."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "from unitest.fixtures.mock_ear_generation import _generate_refined_ear\n",
+    "from pyear.frequency_domain import aggregate_frequency_domain_features\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "blinks, sfreq, epoch_len, n_epochs = _generate_refined_ear()\n",
+    "df = aggregate_frequency_domain_features(blinks, sfreq, n_epochs)\n",
+    "df.head()"
+   ],
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "source": [
+    "plt.figure()\n",
+    "plt.plot(df.index, df['broadband_power_0_5_2'])\n",
+    "plt.xlabel('epoch')\n",
+    "plt.ylabel('0.5-2 Hz power')"
+   ],
+   "execution_count": null,
+   "outputs": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/unitest/test_frequency_domain_features.py
+++ b/unitest/test_frequency_domain_features.py
@@ -1,0 +1,59 @@
+"""Tests for frequency-domain feature extraction."""
+import unittest
+import math
+import logging
+import mne
+
+from pyear.frequency_domain.features import compute_frequency_domain_features
+from pyear.frequency_domain.aggregate import aggregate_frequency_domain_features
+from pyear.utils import slice_raw_to_segments
+from unitest.fixtures.mock_ear_generation import _generate_refined_ear
+
+logger = logging.getLogger(__name__)
+
+
+class TestFrequencyFeatures(unittest.TestCase):
+    """Validate frequency-domain metrics."""
+
+    def setUp(self) -> None:
+        blinks, sfreq, epoch_len, n_epochs = _generate_refined_ear()
+        self.sfreq = sfreq
+        self.per_epoch = [[] for _ in range(n_epochs)]
+        for blink in blinks:
+            self.per_epoch[blink["epoch_index"]].append(blink)
+        self.blinks = blinks
+        self.n_epochs = n_epochs
+
+    def test_single_epoch_features(self) -> None:
+        """Check a couple of features for the first epoch."""
+        signal = self.per_epoch[0][0]["epoch_signal"]
+        feats = compute_frequency_domain_features(self.per_epoch[0], signal, self.sfreq)
+        logger.debug("Freq features epoch 0: %s", feats)
+        self.assertAlmostEqual(feats["blink_rate_peak_freq"], 0.3, places=1)
+        self.assertTrue(feats["wavelet_energy_d1"] > 0)
+
+    def test_aggregate_shape(self) -> None:
+        """Aggregating across epochs should return expected DataFrame size."""
+        df = aggregate_frequency_domain_features(self.blinks, self.sfreq, self.n_epochs)
+        logger.debug("Freq feature DataFrame head: %s", df.head())
+        self.assertEqual(df.shape[0], self.n_epochs)
+        self.assertEqual(df.shape[1], 11)
+        self.assertTrue(math.isnan(df.loc[3, "blink_rate_peak_freq"]))
+
+
+class TestSegmentationHelper(unittest.TestCase):
+    """Tests for the raw slicing helper."""
+
+    def test_segment_count(self) -> None:
+        """Ensure the helper slices a raw file into multiple segments."""
+        raw = mne.io.read_raw_fif("unitest/ear_eog.fif", preload=False, verbose=False)
+        segments = slice_raw_to_segments(raw, epoch_len=30.0)
+        logger.debug("Created %d segments", len(segments))
+        self.assertGreater(len(segments), 1)
+        for seg in segments:
+            self.assertIsInstance(seg, mne.io.BaseRaw)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement frequency-domain features (power spectra & wavelet energy)
- add raw segmentation helper with progress bar
- package project via `pyproject.toml`
- document new features and helper
- include tutorial notebook example
- ensure tests cover frequency metrics and slicing helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f54ae61f88325a6a932e672716e80