### PR TITLE
Add blink segmentation test with per-epoch checks

### DIFF
--- a/unitest/test_slice_into_mini_raws.py
+++ b/unitest/test_slice_into_mini_raws.py
@@ -1,0 +1,55 @@
+"""Blink count validation for raw segmentation.
+
+This test ensures that ``slice_into_mini_raws`` correctly counts blinks in
+30-second segments of the ``ear_eog.fif`` recording.  The expected blink counts
+for the first ten segments are stored in
+``ear_eog_blink_count_epoch.csv``.
+"""
+
+import logging
+import tempfile
+from pathlib import Path
+import unittest
+
+import mne
+import pandas as pd
+
+from ground_truth.epoch_blink_overlay import slice_into_mini_raws
+
+logger = logging.getLogger(__name__)
+
+
+class TestSliceIntoMiniRaws(unittest.TestCase):
+    """Verify blink counts from 30-second raw segments."""
+
+    def setUp(self) -> None:
+        """Run ``slice_into_mini_raws`` once for use in all tests."""
+        raw = mne.io.read_raw_fif("unitest/ear_eog.fif", preload=False, verbose=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.df, _ = slice_into_mini_raws(
+                raw=raw,
+                out_dir=Path(tmpdir),
+                epoch_len=30.0,
+                save=False,
+                report=None,
+                blink_label=None,
+            )
+        self.expected = pd.read_csv(Path("unitest/ear_eog_blink_count_epoch.csv"))
+
+    def test_each_segment(self) -> None:
+        """Check blink count for each of the first ten segments individually."""
+        for idx, expected_count in enumerate(self.expected["blink_count"]):
+            with self.subTest(segment=idx):
+                result = int(self.df.loc[idx, "blink_count"])
+                self.assertEqual(result, expected_count)
+
+    def test_total_blink_count(self) -> None:
+        """Total blink count across the first ten segments should match."""
+        result_total = int(self.df.loc[: len(self.expected) - 1, "blink_count"].sum())
+        expected_total = int(self.expected["blink_count"].sum())
+        self.assertEqual(result_total, expected_total)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `test_slice_into_mini_raws` to check blink counts for each 30‑second segment
- verify total blink count across all 10 ground-truth segments

## Testing
- `python -m unittest discover -s unitest -p 'test_*.py'`

------
https://chatgpt.com/codex/tasks/task_e_685f5b747e948325a53996ea7cf8d770