### PR TITLE
Refactor epoch slicing utilities

### DIFF
--- a/pyear/utils/__init__.py
+++ b/pyear/utils/__init__.py
@@ -1,4 +1,16 @@
 """Utility functions for pyear."""
 from .segments import slice_raw_to_segments
+from .epochs import (
+    slice_raw_into_epochs,
+    save_epoch_raws,
+    generate_epoch_report,
+    slice_into_mini_raws,
+)
 
-__all__ = ["slice_raw_to_segments"]
+__all__ = [
+    "slice_raw_to_segments",
+    "slice_raw_into_epochs",
+    "save_epoch_raws",
+    "generate_epoch_report",
+    "slice_into_mini_raws",
+]

--- a/pyear/utils/epochs.py
+++ b/pyear/utils/epochs.py
@@ -1,7 +1,9 @@
 """Epoching utilities for time-series data."""
+from __future__ import annotations
+
 import logging
 from pathlib import Path
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Sequence
 
 import matplotlib.pyplot as plt
 import mne
@@ -24,40 +26,37 @@ logger = logging.getLogger(__name__)
 # Core utility functions
 # -----------------------------------------------------------------------------
 
-def slice_into_mini_raws(
-        raw: mne.io.BaseRaw,
-        out_dir: Path,
-        epoch_len: float = EPOCH_LEN,
-        save: bool = True,
-        report: Optional[mne.Report] = None,
-        blink_label: Optional[str] = BLINK_LABEL,
-) -> Tuple[pd.DataFrame, List[Tuple[int, int]]]:
-    """Slice a raw recording into epochs and count blinks.
+def slice_raw_into_epochs(
+    raw: mne.io.BaseRaw,
+    *,
+    epoch_len: float = EPOCH_LEN,
+    blink_label: Optional[str] = BLINK_LABEL,
+) -> Tuple[List[mne.io.BaseRaw], pd.DataFrame, List[Tuple[int, int]], List[Tuple[float, float]]]:
+    """Slice a raw recording into epochs and count blink annotations.
 
     Parameters
     ----------
     raw : mne.io.BaseRaw
         Continuous recording with blink annotations.
-    out_dir : Path
-        Directory to save epoch files, if enabled.
-    epoch_len : float
-        Length of each epoch in seconds.
-    save : bool
-        Whether to write each epoch raw file to disk.
-    report : mne.Report | None
-        Report object to which figures will be added.
-    blink_label : str | None
-        Description label to filter blink annotations.
+    epoch_len : float, optional
+        Length of each epoch in seconds. Defaults to :data:`EPOCH_LEN`.
+    blink_label : str | None, optional
+        Annotation label to filter blinks. ``None`` counts all annotations.
 
     Returns
     -------
-    df : pandas.DataFrame
-        Epoch blink counts (columns: "epoch_id", "blink_count").
-    boundary_pairs : list of tuple
-        Pairs of epoch indices where a blink spans a boundary.
+    list of mne.io.BaseRaw
+        Epochs cropped from the input raw with annotations shifted relative to
+        each epoch.
+    pandas.DataFrame
+        Blink counts per epoch with columns ``epoch_id`` and ``blink_count``.
+    list of tuple
+        Pairs of epoch indices where a blink spans the boundary between epochs.
+    list of tuple
+        Start and stop times for each epoch (seconds) relative to the original
+        raw.
     """
-    logger.info("Entering slice_into_mini_raws")
-    out_dir.mkdir(parents=True, exist_ok=True)
+    logger.info("Slicing raw into epochs (%.1fs)", epoch_len)
 
     ann = raw.annotations
     mask = np.ones(len(ann), dtype=bool)
@@ -68,12 +67,15 @@ def slice_into_mini_raws(
 
     total_time = raw.times[-1]
     n_epochs = int(np.ceil(total_time / epoch_len))
-    counts = [0] * n_epochs
+    counts: List[int] = [0] * n_epochs
     boundary_pairs: List[Tuple[int, int]] = []
+    epochs: List[mne.io.BaseRaw] = []
+    times: List[Tuple[float, float]] = []
 
     for i in tqdm(range(n_epochs), desc="Cropping epochs", unit="epoch"):
         start = i * epoch_len
         stop = min(start + epoch_len, total_time)
+        times.append((start, stop))
 
         in_epoch = (onsets >= start) & (onsets < stop)
         counts[i] = int(np.sum(in_epoch))
@@ -90,22 +92,126 @@ def slice_into_mini_raws(
             description=ann_epoch.description,
         )
         mini.set_annotations(shifted)
-        # mini.plot()
-        fig = mini.plot(
-            n_channels=min(10, len(mini.ch_names)),
-            scalings="auto",
-            title=f"Epoch {i} ({start:.2f}-{stop:.2f}s)",
-            show=False,
-        )
-        if report is not None:
-            report.add_figure(fig, title=f"Epoch {i}", section="epochs")
-        if save:
-            fname = out_dir / f"epoch_{i:04d}_{start:07.2f}s-{stop:07.2f}s_raw.fif"
-            mini.save(fname, overwrite=True)
-        plt.close(fig)
+        epochs.append(mini)
 
     df = pd.DataFrame({"epoch_id": range(n_epochs), "blink_count": counts})
     logger.debug("Blink counts per epoch: %s", counts)
     logger.debug("Cross-boundary pairs: %s", boundary_pairs)
+    return epochs, df, boundary_pairs, times
+
+def save_epoch_raws(
+    epochs: Sequence[mne.io.BaseRaw],
+    times: Sequence[Tuple[float, float]],
+    out_dir: Path,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Save cropped raw epochs to disk.
+
+    Parameters
+    ----------
+    epochs : sequence of mne.io.BaseRaw
+        Epochs returned by :func:`slice_raw_into_epochs`.
+    times : sequence of tuple
+        Start and stop time pairs for file naming.
+    out_dir : pathlib.Path
+        Directory to write the files.
+    overwrite : bool, optional
+        Whether to overwrite existing files. Defaults to ``False``.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, (epoch, span) in enumerate(zip(epochs, times)):
+        start, stop = span
+        fname = out_dir / f"epoch_{idx:04d}_{start:07.2f}s-{stop:07.2f}s_raw.fif"
+        if fname.exists() and not overwrite:
+            logger.debug("Skipping existing %s", fname)
+            continue
+        epoch.save(fname, overwrite=overwrite)
+
+
+def generate_epoch_report(
+    epochs: Sequence[mne.io.BaseRaw],
+    times: Sequence[Tuple[float, float]],
+) -> mne.Report:
+    """Create a simple report visualizing each epoch.
+
+    Parameters
+    ----------
+    epochs : sequence of mne.io.BaseRaw
+        Epoch data to plot.
+    times : sequence of tuple
+        Start and stop time pairs for titles.
+
+    Returns
+    -------
+    mne.Report
+        Report containing one figure per epoch.
+    """
+    report = mne.Report(title="Epoch Overview")
+    for idx, (epoch, span) in enumerate(zip(epochs, times)):
+        start, stop = span
+        fig = epoch.plot(
+            n_channels=min(10, len(epoch.ch_names)),
+            scalings="auto",
+            title=f"Epoch {idx} ({start:.2f}-{stop:.2f}s)",
+            show=False,
+        )
+        report.add_figure(fig, title=f"Epoch {idx}", section="epochs")
+        plt.close(fig)
+    return report
+
+def slice_into_mini_raws(
+    raw: mne.io.BaseRaw,
+    out_dir: Path,
+    *,
+    epoch_len: float = EPOCH_LEN,
+    blink_label: Optional[str] = BLINK_LABEL,
+    save: bool = True,
+    overwrite: bool = False,
+    report: bool = False,
+) -> Tuple[List[mne.io.BaseRaw], pd.DataFrame, List[Tuple[int, int]], Optional[mne.Report]]:
+    """Slice a raw recording into epochs with optional saving and reporting.
+
+    Parameters
+    ----------
+    raw : mne.io.BaseRaw
+        Continuous recording with blink annotations.
+    out_dir : Path
+        Directory to save epoch files and/or report.
+    epoch_len : float, optional
+        Length of each epoch in seconds. Defaults to :data:`EPOCH_LEN`.
+    blink_label : str | None, optional
+        Annotation label used to filter blinks. ``None`` counts all
+        annotations.
+    save : bool, optional
+        Whether to write epoch files to ``out_dir``. Defaults to ``True``.
+    overwrite : bool, optional
+        Overwrite any existing files when ``save`` is ``True``. Defaults to
+        ``False``.
+    report : bool, optional
+        Generate and optionally save an ``mne.Report`` to ``out_dir``. The
+        report is only produced when both ``report`` and ``save`` are ``True``.
+
+    Returns
+    -------
+    list of mne.io.BaseRaw
+        Epoch objects retained in memory.
+    pandas.DataFrame
+        Blink counts per epoch.
+    list of tuple
+        Boundary pairs spanning adjacent epochs.
+    mne.Report | None
+        The generated report if requested, otherwise ``None``.
+    """
+    logger.info("Entering slice_into_mini_raws")
+    epochs, df, boundary_pairs, times = slice_raw_into_epochs(
+        raw, epoch_len=epoch_len, blink_label=blink_label
+    )
+    rep: Optional[mne.Report] = None
+    if save:
+        save_epoch_raws(epochs, times, out_dir, overwrite=overwrite)
+        if report:
+            rep = generate_epoch_report(epochs, times)
+            rep.save(out_dir / "epoch_report.html", overwrite=overwrite, open_browser=False)
     logger.info("Exiting slice_into_mini_raws")
-    return df, boundary_pairs
+    return epochs, df, boundary_pairs, rep

--- a/unitest/test_raw_blink_count.py
+++ b/unitest/test_raw_blink_count.py
@@ -1,0 +1,60 @@
+"""Blink count validation for individual raw epochs."""
+import logging
+from pathlib import Path
+import tempfile
+import unittest
+
+import mne
+import pandas as pd
+import numpy as np
+
+from pyear.utils.epochs import slice_into_mini_raws
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestRawBlinkCount(unittest.TestCase):
+    """Compare blink counts from sliced raw epochs to expected values."""
+
+    def setUp(self) -> None:
+        raw_path = PROJECT_ROOT / "unitest" / "ear_eog.fif"
+        expected_csv_path = PROJECT_ROOT / "unitest" / "ear_eog_blink_count_epoch.csv"
+        raw = mne.io.read_raw_fif(raw_path, preload=False, verbose=False)
+        (
+            self.epochs,
+            self.df,
+            _,
+            _,
+        ) = slice_into_mini_raws(
+            raw,
+            Path(tempfile.mkdtemp()),
+            epoch_len=30.0,
+            blink_label=None,
+            save=False,
+            overwrite=False,
+            report=False,
+        )
+        self.expected = pd.read_csv(expected_csv_path)
+
+    @staticmethod
+    def _count_blinks(raw: mne.io.BaseRaw, label: str | None = "blink") -> int:
+        mask = np.ones(len(raw.annotations), dtype=bool)
+        if label is not None:
+            mask &= raw.annotations.description == label
+        return int(mask.sum())
+
+    def test_total_blink_count(self) -> None:
+        """Validate blink counts for selected raw indices."""
+        checks = {0: 2, 13: 4, 49: 13}
+        for idx, expected in checks.items():
+            count = self._count_blinks(self.epochs[idx], label=None)
+            self.assertEqual(count, expected)
+            self.assertEqual(count, int(self.df.loc[idx, "blink_count"]))
+            self.assertEqual(count, int(self.expected.loc[idx, "blink_count"]))
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/unitest/test_slice_into_mini_raws.py
+++ b/unitest/test_slice_into_mini_raws.py
@@ -1,59 +1,89 @@
-"""Blink count validation for raw segmentation.
+"""Integration tests for ``slice_into_mini_raws``.
 
-This test ensures that ``slice_into_mini_raws`` correctly counts blinks in
-30-second segments of the ``ear_eog.fif`` recording.  The expected blink counts
-for the first ten segments are stored in
-``ear_eog_blink_count_epoch.csv``.
+This test creates a synthetic raw recording with blink annotations, slices it
+into epochs, saves them to disk and verifies that the saved files match the
+in-memory epochs. Blink counts per epoch are also validated.
 """
-
 import logging
 import tempfile
 from pathlib import Path
 import unittest
 
 import mne
-import pandas as pd
+import numpy as np
 
 from pyear.utils.epochs import slice_into_mini_raws
 
 logger = logging.getLogger(__name__)
 
-# Get the project root directory
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
-
 
 class TestSliceIntoMiniRaws(unittest.TestCase):
-    """Verify blink counts from 30-second raw segments."""
+    """Validate slicing and saving of raw epochs."""
 
     def setUp(self) -> None:
-        """Run ``slice_into_mini_raws`` once for use in all tests."""
-        raw_path = PROJECT_ROOT / "unitest" / "ear_eog.fif"
-        expected_csv_path = PROJECT_ROOT / "unitest" / "ear_eog_blink_count_epoch.csv"
+        self.sfreq = 50.0
+        self.epoch_len = 10.0
+        self.n_epochs = 3
+        n_samples = int(self.sfreq * self.epoch_len * self.n_epochs)
+        rng = np.random.default_rng(0)
+        data = rng.normal(scale=1e-6, size=(1, n_samples))
+        info = mne.create_info(["EOG"], self.sfreq, ["misc"])
+        raw = mne.io.RawArray(data, info, verbose=False)
+        onsets = np.array([2.0, 5.0, 12.0, 18.0, 22.0])
+        durations = np.repeat(0.1, len(onsets))
+        raw.set_annotations(mne.Annotations(onsets, durations, ["blink"] * len(onsets)))
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.out_dir = Path(self.tmp_dir.name)
+        (
+            self.epochs,
+            self.df,
+            _,
+            _,
+        ) = slice_into_mini_raws(
+            raw,
+            self.out_dir,
+            epoch_len=self.epoch_len,
+            blink_label="blink",
+            save=True,
+            overwrite=True,
+            report=False,
+        )
+        self.saved_epochs = [
+            mne.io.read_raw_fif(p, preload=True, verbose=False)
+            for p in sorted(self.out_dir.glob("epoch_*_raw.fif"))
+        ]
+        self.expected_counts = [2, 2, 1]
 
-        raw = mne.io.read_raw_fif(raw_path, preload=False, verbose=False)
-        with tempfile.TemporaryDirectory() as tmpdir:
-            self.df, _ = slice_into_mini_raws(
-                raw=raw,
-                out_dir=Path(tmpdir),
-                epoch_len=30.0,
-                save=False,
-                report=None,
-                blink_label=None,
+    def tearDown(self) -> None:
+        self.tmp_dir.cleanup()
+
+    @staticmethod
+    def _count_blinks(raw: mne.io.BaseRaw, label: str = "blink") -> int:
+        mask = np.ones(len(raw.annotations), dtype=bool)
+        if label is not None:
+            mask &= raw.annotations.description == label
+        return int(mask.sum())
+
+    def test_saved_equals_memory(self) -> None:
+        """Saved epochs should be identical to in-memory epochs."""
+        self.assertEqual(len(self.epochs), len(self.saved_epochs))
+        for mem, disk in zip(self.epochs, self.saved_epochs):
+            np.testing.assert_allclose(mem.get_data(), disk.get_data())
+            np.testing.assert_array_equal(mem.annotations.onset, disk.annotations.onset)
+            self.assertListEqual(
+                list(mem.annotations.description),
+                list(disk.annotations.description),
             )
-        self.expected = pd.read_csv(expected_csv_path)
 
-    def test_each_segment(self) -> None:
-        """Check blink count for each of the first ten segments individually."""
-        for idx, expected_count in enumerate(self.expected["blink_count"]):
-            with self.subTest(segment=idx):
-                result = int(self.df.loc[idx, "blink_count"])
-                self.assertEqual(result, expected_count)
-
-    def test_total_blink_count(self) -> None:
-        """Total blink count across the first ten segments should match."""
-        result_total = int(self.df.loc[: len(self.expected) - 1, "blink_count"].sum())
-        expected_total = int(self.expected["blink_count"].sum())
-        self.assertEqual(result_total, expected_total)
+    def test_blink_counts(self) -> None:
+        """Blink counts match expectation for each epoch."""
+        for idx, raw in enumerate(self.epochs):
+            count = self._count_blinks(raw)
+            self.assertEqual(count, self.expected_counts[idx])
+            self.assertEqual(count, int(self.df.loc[idx, "blink_count"]))
+        for idx, raw in enumerate(self.saved_epochs):
+            count = self._count_blinks(raw)
+            self.assertEqual(count, self.expected_counts[idx])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- refactor `slice_into_mini_raws` into modular helpers
- add ability to save and report on sliced epochs
- expose new utilities from `pyear.utils`
- update tests to use synthetic raws
- add test for blink counts on saved raws

## Testing
- `python -m unittest discover -s unitest -p 'test_*.py'` *(fails: ModuleNotFoundError: No module named 'ground_truth')*

------
https://chatgpt.com/codex/tasks/task_e_6861ce9d5bf0832594bf316d8509a20c