### PR TITLE
Add refined blink plotting and consolidate stubs

### DIFF
--- a/ground_truth/__init__.py
+++ b/ground_truth/__init__.py
@@ -1,0 +1,1 @@
+"""Reference implementations used in tests."""

--- a/ground_truth/epoch_blink_overlay.py
+++ b/ground_truth/epoch_blink_overlay.py
@@ -1,0 +1,20 @@
+"""Simple blink count summarization used for test comparison."""
+from __future__ import annotations
+
+from typing import Tuple, Optional
+
+import mne
+import pandas as pd
+
+from pyear.utils.epochs import slice_raw_into_epochs
+
+
+def summarize_blink_counts(
+    raw: mne.io.BaseRaw,
+    *,
+    epoch_len: float = 30.0,
+    blink_label: Optional[str] = None,
+) -> Tuple[pd.DataFrame, list[mne.io.BaseRaw]]:
+    """Return blink counts per epoch using pyear utilities."""
+    epochs, df, _, _ = slice_raw_into_epochs(raw, epoch_len=epoch_len, blink_label=blink_label)
+    return df, epochs

--- a/pyear/utils/__init__.py
+++ b/pyear/utils/__init__.py
@@ -6,6 +6,12 @@ from .epochs import (
     generate_epoch_report,
     slice_into_mini_raws,
 )
+from .refinement import (
+    refine_ear_extrema_and_threshold_stub,
+    refine_local_maximum_stub,
+    refine_blinks_from_epochs,
+    plot_refined_blinks,
+)
 
 __all__ = [
     "slice_raw_to_segments",
@@ -13,4 +19,8 @@ __all__ = [
     "save_epoch_raws",
     "generate_epoch_report",
     "slice_into_mini_raws",
+    "refine_ear_extrema_and_threshold_stub",
+    "refine_local_maximum_stub",
+    "refine_blinks_from_epochs",
+    "plot_refined_blinks",
 ]

--- a/pyear/utils/refinement.py
+++ b/pyear/utils/refinement.py
@@ -1,0 +1,217 @@
+"""Blink refinement utilities for EEG/EOG signals."""
+from __future__ import annotations
+
+from typing import Sequence, Dict, Any, Callable, Tuple, List, Optional
+import logging
+import matplotlib.pyplot as plt
+
+import mne
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def refine_ear_extrema_and_threshold_stub(
+    signal_segment: np.ndarray,
+    start_rel: int,
+    end_rel: int,
+    peak_rel_cvat: int | None = None,
+    *,
+    local_max_prominence: float = 0.01,
+    search_expansion_frames: int = 5,
+    value_threshold: float | None = None,
+) -> Tuple[int, int, int]:
+    """Return a crude EAR trough refinement.
+
+    Parameters mirror those of the real refinement routine but the
+    implementation merely validates that indices are within bounds and
+    estimates a trough location if ``peak_rel_cvat`` is not supplied.
+
+    Returns
+    -------
+    tuple
+        ``(start_frame, trough_frame, end_frame)`` indices within the segment.
+    """
+
+    valid_trough = peak_rel_cvat
+    if not (peak_rel_cvat is not None and 0 <= peak_rel_cvat < len(signal_segment)):
+        if end_rel >= start_rel and len(signal_segment) > 0:
+            valid_trough = (start_rel + end_rel) // 2
+        else:
+            valid_trough = 0
+
+    rs_stub = max(0, min(start_rel, len(signal_segment) - 1 if len(signal_segment) > 0 else 0))
+    re_stub = max(0, min(end_rel, len(signal_segment) - 1 if len(signal_segment) > 0 else 0))
+    if rs_stub > re_stub:
+        rs_stub = re_stub
+
+    return rs_stub, valid_trough, re_stub
+
+
+def refine_local_maximum_stub(
+    signal_segment: np.ndarray,
+    start_rel: int,
+    end_rel: int,
+    peak_rel_cvat: int | None = None,
+    *,
+    local_max_prominence: float = 0.01,
+    search_expansion_frames: int = 5,
+    value_threshold: float | None = None,
+) -> Tuple[int, int, int]:
+    """Return a crude refinement for local maxima.
+
+    This function mirrors :func:`refine_ear_extrema_and_threshold_stub` but the
+    extremum is a maximum. The parameters are accepted for API compatibility but
+    are not used in the simplified logic.
+    """
+    rs_stub = max(0, min(start_rel, len(signal_segment) - 1 if len(signal_segment) > 0 else 0))
+    re_stub = max(0, min(end_rel, len(signal_segment) - 1 if len(signal_segment) > 0 else 0))
+    if rs_stub > re_stub:
+        rs_stub = re_stub
+
+    valid_peak = peak_rel_cvat
+    if not (peak_rel_cvat is not None and rs_stub <= peak_rel_cvat <= re_stub):
+        if len(signal_segment) > 0:
+            valid_peak = (rs_stub + re_stub) // 2
+        else:
+            valid_peak = 0
+
+    return rs_stub, valid_peak, re_stub
+
+
+def plot_refined_blinks(
+    refined_blinks: Sequence[Dict[str, Any]],
+    sfreq: float,
+    epoch_len: float,
+    *,
+    epoch_indices: Optional[Sequence[int]] = None,
+    show: bool = False,
+) -> List[plt.Figure]:
+    """Plot signal segments with refined blink markers.
+
+    Parameters
+    ----------
+    refined_blinks : sequence of dict
+        Output from :func:`refine_blinks_from_epochs`.
+    sfreq : float
+        Sampling frequency of the signals.
+    epoch_len : float
+        Duration of each epoch in seconds.
+    epoch_indices : sequence of int | None, optional
+        Specific epochs to plot. If ``None`` all epochs containing blinks are
+        shown.
+    show : bool, optional
+        Whether to display the figures using ``plt.show``. Defaults to ``False``.
+
+    Returns
+    -------
+    list of matplotlib.figure.Figure
+        Figure objects created for each plotted epoch.
+    """
+
+    epochs_to_plot: Dict[int, Dict[str, Any]] = {}
+    for blink in refined_blinks:
+        idx = blink["epoch_index"]
+        if epoch_indices is None or idx in epoch_indices:
+            if idx not in epochs_to_plot:
+                epochs_to_plot[idx] = {"signal": blink["epoch_signal"], "blinks": []}
+            epochs_to_plot[idx]["blinks"].append(blink)
+
+    if not epochs_to_plot:
+        logger.warning("No epochs selected for plotting")
+        return []
+
+    figs: List[plt.Figure] = []
+    time_axis = np.arange(0, epoch_len, 1.0 / sfreq)
+    for epoch_index, data in epochs_to_plot.items():
+        fig, ax = plt.subplots(figsize=(15, 5))
+        ax.plot(time_axis, data["signal"], label="Signal")
+        for blink in data["blinks"]:
+            start_t = blink["refined_start_frame"] / sfreq
+            peak_t = blink["refined_peak_frame"] / sfreq
+            end_t = blink["refined_end_frame"] / sfreq
+            ax.axvline(start_t, color="g", linestyle="--")
+            ax.axvline(peak_t, color="r")
+            ax.axvline(end_t, color="b", linestyle="--")
+        ax.set_title(f"Epoch {epoch_index}")
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel("Amplitude")
+        ax.grid(True)
+        figs.append(fig)
+        if show:
+            plt.show()
+        else:
+            plt.close(fig)
+
+    return figs
+
+
+def refine_blinks_from_epochs(
+    epochs: Sequence[mne.io.BaseRaw],
+    channel: str,
+    *,
+    refine_func: Callable[[np.ndarray, int, int, int | None], Tuple[int, int, int]] = refine_local_maximum_stub,
+    local_max_prominence: float = 0.01,
+    search_expansion_frames: int | None = None,
+    value_threshold: float | None = None,
+) -> List[Dict[str, Any]]:
+    """Refine blink annotations within pre-sliced epochs.
+
+    Parameters
+    ----------
+    epochs : sequence of mne.io.BaseRaw
+        Epochs produced by :func:`slice_into_mini_raws` containing annotations.
+    channel : str
+        Channel name used for refinement.
+    refine_func : callable, optional
+        Refinement function taking ``(signal_segment, start_rel, end_rel, peak_rel_cvat)``
+        and returning ``(start, peak, end)``. Defaults to
+        :func:`refine_local_maximum_stub`.
+    local_max_prominence : float, optional
+        Parameter forwarded to ``refine_func``.
+    search_expansion_frames : int | None, optional
+        Expansion frames for ``refine_func``. When ``None`` this defaults to
+        ``int(0.1 * sfreq)``.
+    value_threshold : float | None, optional
+        Threshold parameter for ``refine_func``.
+
+    Returns
+    -------
+    list of dict
+        Refined blink annotations with keys ``epoch_index``,
+        ``epoch_signal``, ``refined_start_frame``, ``refined_peak_frame`` and
+        ``refined_end_frame``.
+    """
+    logger.info("Refining blinks across %d epochs", len(epochs))
+    refined: List[Dict[str, Any]] = []
+    if not epochs:
+        return refined
+    sfreq = epochs[0].info["sfreq"]
+    if search_expansion_frames is None:
+        search_expansion_frames = int(0.1 * sfreq)
+
+    for epoch_index, raw in enumerate(epochs):
+        signal = raw.get_data(picks=channel)[0]
+        for ann in raw.annotations:
+            start_frame = int(round(float(ann["onset"]) * sfreq))
+            end_frame = int(round((float(ann["onset"]) + float(ann["duration"])) * sfreq))
+            r_start, r_peak, r_end = refine_func(
+                signal,
+                start_frame,
+                end_frame,
+                None,
+                local_max_prominence=local_max_prominence,
+                search_expansion_frames=search_expansion_frames,
+                value_threshold=value_threshold,
+            )
+            refined.append(
+                {
+                    "epoch_index": epoch_index,
+                    "epoch_signal": signal,
+                    "refined_start_frame": r_start,
+                    "refined_peak_frame": r_peak,
+                    "refined_end_frame": r_end,
+                }
+            )
+    logger.info("Refined %d blink annotations", len(refined))
+    return refined

--- a/unitest/fixtures/ear_refinement_stub.py
+++ b/unitest/fixtures/ear_refinement_stub.py
@@ -1,42 +1,4 @@
-"""Stub for blink refinement.
+"""Compatibility wrapper for refinement stub."""
+from pyear.utils.refinement import refine_ear_extrema_and_threshold_stub
 
-This module provides ``refine_blink_with_ear_extrema_and_threshold_stub`` which
-mimics the behaviour of a more sophisticated blink refinement algorithm. It is
-intended solely for unit testing within this repository.
-"""
-from __future__ import annotations
-
-import numpy as np
-from typing import Tuple
-
-
-def refine_ear_extrema_and_threshold_stub(
-    signal_segment: np.ndarray,
-    start_rel: int,
-    end_rel: int,
-    peak_rel_cvat: int | None = None,
-    *,
-    local_max_prominence: float = 0.01,
-    search_expansion_frames: int = 5,
-    value_threshold: float | None = None,
-) -> Tuple[int, int, int]:
-    """Return a crude ear refinement.
-    currently the logic below is for trough refinement only.The trough is lowest point in the eye aspect ratio segment between the
-    start and end relative indices. If ``peak_rel_cvat`` is provided, it is used
-
-    Parameters mirror those of the real refinement routine but the
-    implementation merely validates that indices are within bounds and
-    estimates a trough location if ``peak_rel_cvat`` is not supplied.
-    """
-    valid_trough = peak_rel_cvat
-    if not (peak_rel_cvat is not None and 0 <= peak_rel_cvat < len(signal_segment)):
-        if end_rel >= start_rel and len(signal_segment) > 0:
-            valid_trough = (start_rel + end_rel) // 2
-        else:
-            valid_trough = 0
-
-    rs_stub = max(0, min(start_rel, len(signal_segment) - 1 if len(signal_segment) > 0 else 0))
-    re_stub = max(0, min(end_rel, len(signal_segment) - 1 if len(signal_segment) > 0 else 0))
-    if rs_stub > re_stub:
-        rs_stub = re_stub
-    return rs_stub, valid_trough, re_stub
+__all__ = ["refine_ear_extrema_and_threshold_stub"]

--- a/unitest/fixtures/mock_ear_generation.py
+++ b/unitest/fixtures/mock_ear_generation.py
@@ -4,7 +4,7 @@ import matplotlib.pyplot as plt
 import mne
 import numpy as np
 
-from unitest.fixtures.ear_refinement_stub import refine_ear_extrema_and_threshold_stub
+from pyear.utils.refinement import refine_ear_extrema_and_threshold_stub
 
 
 def _generate_signal_with_blinks(sfreq: float, epoch_len: float, n_epochs: int) -> Tuple[np.ndarray, List[Dict]]:

--- a/unitest/test_eeg_eog_refinement.py
+++ b/unitest/test_eeg_eog_refinement.py
@@ -1,0 +1,71 @@
+"""Tests for blink refinement on EEG and EOG channels."""
+import logging
+import tempfile
+from pathlib import Path
+import unittest
+
+import mne
+
+from pyear.utils.epochs import slice_into_mini_raws
+from pyear.utils.refinement import refine_blinks_from_epochs, plot_refined_blinks
+
+logger = logging.getLogger(__name__)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestEEGEOGRefinement(unittest.TestCase):
+    """Ensure refinement works on both EEG and EOG modalities."""
+
+    def setUp(self) -> None:
+        raw_path = PROJECT_ROOT / "unitest" / "ear_eog.fif"
+        raw = mne.io.read_raw_fif(raw_path, preload=False, verbose=False)
+        (
+            self.epochs,
+            self.df,
+            _,
+            _,
+        ) = slice_into_mini_raws(
+            raw,
+            Path(tempfile.mkdtemp()),
+            epoch_len=30.0,
+            blink_label=None,
+            save=False,
+            overwrite=False,
+            report=False,
+        )
+        self.total_ann = sum(len(ep.annotations) for ep in self.epochs)
+
+    def _run_channel(self, channel: str) -> None:
+        logger.info("Refinement test on %s", channel)
+        refined = refine_blinks_from_epochs(self.epochs, channel)
+        self.assertEqual(len(refined), self.total_ann)
+        for blink in refined:
+            n_times = len(blink["epoch_signal"])
+            self.assertTrue(0 <= blink["refined_start_frame"] <= n_times)
+            self.assertTrue(0 <= blink["refined_peak_frame"] <= n_times)
+            self.assertTrue(0 <= blink["refined_end_frame"] <= n_times)
+            self.assertLessEqual(blink["refined_start_frame"], blink["refined_peak_frame"])
+            self.assertLessEqual(blink["refined_peak_frame"], blink["refined_end_frame"])
+        # sanity plot for first epoch without showing
+        figs = plot_refined_blinks(
+            refined,
+            self.epochs[0].info["sfreq"],
+            30.0,
+            epoch_indices=[0],
+            show=False,
+        )
+        self.assertTrue(len(figs) >= 1)
+
+    def test_eeg_e8(self) -> None:
+        """Run refinement on EEG channel."""
+        self._run_channel("EEG-E8")
+
+    def test_eog_vertical(self) -> None:
+        """Run refinement on EOG channel."""
+        self._run_channel("EOG-EEG-eog_vert_left")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
## Summary
- move EAR refinement stub into main utilities
- expose new `plot_refined_blinks` helper
- ensure fixtures import from utilities
- update EEG/EOG refinement tests to plot first epoch

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e4cb59d88325abeb02a7ce715555