### PR TITLE
Clarify segment naming

### DIFF
--- a/ground_truth/epoch_blink_overlay.py
+++ b/ground_truth/epoch_blink_overlay.py
@@ -15,6 +15,8 @@ def summarize_blink_counts(
     epoch_len: float = 30.0,
     blink_label: Optional[str] = None,
 ) -> Tuple[pd.DataFrame, list[mne.io.BaseRaw]]:
-    """Return blink counts per epoch using pyear utilities."""
-    epochs, df, _, _ = slice_raw_into_epochs(raw, epoch_len=epoch_len, blink_label=blink_label)
-    return df, epochs
+    """Return blink counts per segment using pyear utilities."""
+    segments, df, _, _ = slice_raw_into_epochs(
+        raw, epoch_len=epoch_len, blink_label=blink_label
+    )
+    return df, segments

--- a/pyear/utils/epochs.py
+++ b/pyear/utils/epochs.py
@@ -46,8 +46,8 @@ def slice_raw_into_epochs(
     Returns
     -------
     list of mne.io.BaseRaw
-        Epochs cropped from the input raw with annotations shifted relative to
-        each epoch.
+        Raw segments cropped from the input recording with annotations shifted
+        relative to each segment.
     pandas.DataFrame
         Blink counts per epoch with columns ``epoch_id`` and ``blink_count``.
     list of tuple
@@ -69,7 +69,7 @@ def slice_raw_into_epochs(
     n_epochs = int(np.ceil(total_time / epoch_len))
     counts: List[int] = [0] * n_epochs
     boundary_pairs: List[Tuple[int, int]] = []
-    epochs: List[mne.io.BaseRaw] = []
+    segments: List[mne.io.BaseRaw] = []
     times: List[Tuple[float, float]] = []
 
     for i in tqdm(range(n_epochs), desc="Cropping epochs", unit="epoch"):
@@ -92,26 +92,26 @@ def slice_raw_into_epochs(
             description=ann_epoch.description,
         )
         mini.set_annotations(shifted)
-        epochs.append(mini)
+        segments.append(mini)
 
     df = pd.DataFrame({"epoch_id": range(n_epochs), "blink_count": counts})
     logger.debug("Blink counts per epoch: %s", counts)
     logger.debug("Cross-boundary pairs: %s", boundary_pairs)
-    return epochs, df, boundary_pairs, times
+    return segments, df, boundary_pairs, times
 
 def save_epoch_raws(
-    epochs: Sequence[mne.io.BaseRaw],
+    segments: Sequence[mne.io.BaseRaw],
     times: Sequence[Tuple[float, float]],
     out_dir: Path,
     *,
     overwrite: bool = False,
 ) -> None:
-    """Save cropped raw epochs to disk.
+    """Save cropped raw segments to disk.
 
     Parameters
     ----------
-    epochs : sequence of mne.io.BaseRaw
-        Epochs returned by :func:`slice_raw_into_epochs`.
+    segments : sequence of mne.io.BaseRaw
+        Segments returned by :func:`slice_raw_into_epochs`.
     times : sequence of tuple
         Start and stop time pairs for file naming.
     out_dir : pathlib.Path
@@ -120,38 +120,38 @@ def save_epoch_raws(
         Whether to overwrite existing files. Defaults to ``False``.
     """
     out_dir.mkdir(parents=True, exist_ok=True)
-    for idx, (epoch, span) in enumerate(zip(epochs, times)):
+    for idx, (segment, span) in enumerate(zip(segments, times)):
         start, stop = span
         fname = out_dir / f"epoch_{idx:04d}_{start:07.2f}s-{stop:07.2f}s_raw.fif"
         if fname.exists() and not overwrite:
             logger.debug("Skipping existing %s", fname)
             continue
-        epoch.save(fname, overwrite=overwrite)
+        segment.save(fname, overwrite=overwrite)
 
 
 def generate_epoch_report(
-    epochs: Sequence[mne.io.BaseRaw],
+    segments: Sequence[mne.io.BaseRaw],
     times: Sequence[Tuple[float, float]],
 ) -> mne.Report:
-    """Create a simple report visualizing each epoch.
+    """Create a simple report visualizing each segment.
 
     Parameters
     ----------
-    epochs : sequence of mne.io.BaseRaw
-        Epoch data to plot.
+    segments : sequence of mne.io.BaseRaw
+        Segment data to plot.
     times : sequence of tuple
         Start and stop time pairs for titles.
 
     Returns
     -------
     mne.Report
-        Report containing one figure per epoch.
+        Report containing one figure per segment.
     """
     report = mne.Report(title="Epoch Overview")
-    for idx, (epoch, span) in enumerate(zip(epochs, times)):
+    for idx, (segment, span) in enumerate(zip(segments, times)):
         start, stop = span
-        fig = epoch.plot(
-            n_channels=min(10, len(epoch.ch_names)),
+        fig = segment.plot(
+            n_channels=min(10, len(segment.ch_names)),
             scalings="auto",
             title=f"Epoch {idx} ({start:.2f}-{stop:.2f}s)",
             show=False,
@@ -195,7 +195,7 @@ def slice_into_mini_raws(
     Returns
     -------
     list of mne.io.BaseRaw
-        Epoch objects retained in memory.
+        Raw segments retained in memory.
     pandas.DataFrame
         Blink counts per epoch.
     list of tuple
@@ -204,14 +204,14 @@ def slice_into_mini_raws(
         The generated report if requested, otherwise ``None``.
     """
     logger.info("Entering slice_into_mini_raws")
-    epochs, df, boundary_pairs, times = slice_raw_into_epochs(
+    segments, df, boundary_pairs, times = slice_raw_into_epochs(
         raw, epoch_len=epoch_len, blink_label=blink_label
     )
     rep: Optional[mne.Report] = None
     if save:
-        save_epoch_raws(epochs, times, out_dir, overwrite=overwrite)
+        save_epoch_raws(segments, times, out_dir, overwrite=overwrite)
         if report:
-            rep = generate_epoch_report(epochs, times)
+            rep = generate_epoch_report(segments, times)
             rep.save(out_dir / "epoch_report.html", overwrite=overwrite, open_browser=False)
     logger.info("Exiting slice_into_mini_raws")
-    return epochs, df, boundary_pairs, rep
+    return segments, df, boundary_pairs, rep

--- a/pyear/utils/refinement.py
+++ b/pyear/utils/refinement.py
@@ -147,7 +147,7 @@ def plot_refined_blinks(
 
 
 def refine_blinks_from_epochs(
-    epochs: Sequence[mne.io.BaseRaw],
+    segments: Sequence[mne.io.BaseRaw],
     channel: str,
     *,
     refine_func: Callable[[np.ndarray, int, int, int | None], Tuple[int, int, int]] = refine_local_maximum_stub,
@@ -155,12 +155,12 @@ def refine_blinks_from_epochs(
     search_expansion_frames: int | None = None,
     value_threshold: float | None = None,
 ) -> List[Dict[str, Any]]:
-    """Refine blink annotations within pre-sliced epochs.
+    """Refine blink annotations within pre-sliced raw segments.
 
     Parameters
     ----------
-    epochs : sequence of mne.io.BaseRaw
-        Epochs produced by :func:`slice_into_mini_raws` containing annotations.
+    segments : sequence of mne.io.BaseRaw
+        Segments produced by :func:`slice_into_mini_raws` containing annotations.
     channel : str
         Channel name used for refinement.
     refine_func : callable, optional
@@ -182,15 +182,15 @@ def refine_blinks_from_epochs(
         ``epoch_signal``, ``refined_start_frame``, ``refined_peak_frame`` and
         ``refined_end_frame``.
     """
-    logger.info("Refining blinks across %d epochs", len(epochs))
+    logger.info("Refining blinks across %d segments", len(segments))
     refined: List[Dict[str, Any]] = []
-    if not epochs:
+    if not segments:
         return refined
-    sfreq = epochs[0].info["sfreq"]
+    sfreq = segments[0].info["sfreq"]
     if search_expansion_frames is None:
         search_expansion_frames = int(0.1 * sfreq)
 
-    for epoch_index, raw in enumerate(epochs):
+    for epoch_index, raw in enumerate(segments):
         signal = raw.get_data(picks=channel)[0]
         for ann in raw.annotations:
             start_frame = int(round(float(ann["onset"]) * sfreq))

--- a/unitest/test_eeg_eog_refinement.py
+++ b/unitest/test_eeg_eog_refinement.py
@@ -21,7 +21,7 @@ class TestEEGEOGRefinement(unittest.TestCase):
         raw_path = PROJECT_ROOT / "unitest" / "ear_eog.fif"
         raw = mne.io.read_raw_fif(raw_path, preload=False, verbose=False)
         (
-            self.epochs,
+            self.segments,
             self.df,
             _,
             _,
@@ -34,11 +34,11 @@ class TestEEGEOGRefinement(unittest.TestCase):
             overwrite=False,
             report=False,
         )
-        self.total_ann = sum(len(ep.annotations) for ep in self.epochs)
+        self.total_ann = sum(len(seg.annotations) for seg in self.segments)
 
     def _run_channel(self, channel: str) -> None:
         logger.info("Refinement test on %s", channel)
-        refined = refine_blinks_from_epochs(self.epochs, channel)
+        refined = refine_blinks_from_epochs(self.segments, channel)
         self.assertEqual(len(refined), self.total_ann)
         for blink in refined:
             n_times = len(blink["epoch_signal"])
@@ -50,7 +50,7 @@ class TestEEGEOGRefinement(unittest.TestCase):
         # sanity plot for first epoch without showing
         figs = plot_refined_blinks(
             refined,
-            self.epochs[0].info["sfreq"],
+            self.segments[0].info["sfreq"],
             30.0,
             epoch_indices=[0],
             show=False,

--- a/unitest/test_raw_blink_count.py
+++ b/unitest/test_raw_blink_count.py
@@ -23,7 +23,7 @@ class TestRawBlinkCount(unittest.TestCase):
         expected_csv_path = PROJECT_ROOT / "unitest" / "ear_eog_blink_count_epoch.csv"
         raw = mne.io.read_raw_fif(raw_path, preload=False, verbose=False)
         (
-            self.epochs,
+            self.segments,
             self.df,
             _,
             _,
@@ -47,7 +47,7 @@ class TestRawBlinkCount(unittest.TestCase):
         """Validate blink counts for selected raw indices."""
         checks = {0: 2, 13: 4, 49: 13}
         for idx, expected in checks.items():
-            count = self._count_blinks(self.epochs[idx], label=None)
+            count = self._count_blinks(self.segments[idx], label=None)
             self.assertEqual(count, expected)
             self.assertEqual(count, int(self.df.loc[idx, "blink_count"]))
             self.assertEqual(count, int(self.expected.loc[idx, "blink_count"]))

--- a/unitest/test_slice_into_mini_raws.py
+++ b/unitest/test_slice_into_mini_raws.py
@@ -35,7 +35,7 @@ class TestSliceIntoMiniRaws(unittest.TestCase):
         self.tmp_dir = tempfile.TemporaryDirectory()
         self.out_dir = Path(self.tmp_dir.name)
         (
-            self.epochs,
+            self.segments,
             self.df,
             _,
             _,
@@ -48,7 +48,7 @@ class TestSliceIntoMiniRaws(unittest.TestCase):
             overwrite=True,
             report=False,
         )
-        self.saved_epochs = [
+        self.saved_segments = [
             mne.io.read_raw_fif(p, preload=True, verbose=False)
             for p in sorted(self.out_dir.glob("epoch_*_raw.fif"))
         ]
@@ -65,9 +65,9 @@ class TestSliceIntoMiniRaws(unittest.TestCase):
         return int(mask.sum())
 
     def test_saved_equals_memory(self) -> None:
-        """Saved epochs should be identical to in-memory epochs."""
-        self.assertEqual(len(self.epochs), len(self.saved_epochs))
-        for mem, disk in zip(self.epochs, self.saved_epochs):
+        """Saved segments should be identical to in-memory segments."""
+        self.assertEqual(len(self.segments), len(self.saved_segments))
+        for mem, disk in zip(self.segments, self.saved_segments):
             np.testing.assert_allclose(mem.get_data(), disk.get_data())
             np.testing.assert_array_equal(mem.annotations.onset, disk.annotations.onset)
             self.assertListEqual(
@@ -76,12 +76,12 @@ class TestSliceIntoMiniRaws(unittest.TestCase):
             )
 
     def test_blink_counts(self) -> None:
-        """Blink counts match expectation for each epoch."""
-        for idx, raw in enumerate(self.epochs):
+        """Blink counts match expectation for each segment."""
+        for idx, raw in enumerate(self.segments):
             count = self._count_blinks(raw)
             self.assertEqual(count, self.expected_counts[idx])
             self.assertEqual(count, int(self.df.loc[idx, "blink_count"]))
-        for idx, raw in enumerate(self.saved_epochs):
+        for idx, raw in enumerate(self.saved_segments):
             count = self._count_blinks(raw)
             self.assertEqual(count, self.expected_counts[idx])
 


### PR DESCRIPTION
## Summary
- clarify naming of Raw segments in `slice_into_mini_raws` utilities
- rename variables in refinement helpers
- update ground truth helper and related unit tests

## Testing
- `python -m pip install -q -r requirements.txt`
- `pip install -e .`
- `python -m unittest discover unitest`

------
https://chatgpt.com/codex/tasks/task_e_6861ed631ff8832591d222ea2d95ea4a